### PR TITLE
Add watchmy.bike

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,4 @@ A curated list of awesome Strava tools & resources.
 * [StrideStats](https://www.stridestats.com/) - Data about running, set goals, etc.
 * [Summit Bag](https://summitbag.com/) - Automatically identifies your peaks and cols
 * [tapiriik](https://tapiriik.com/) - Sync your fitness data between services
+* [watchmy.bike](https://watchmy.bike/) - Track bikes and components with Strava mileage, maintenance reminders, and public bike profiles


### PR DESCRIPTION
Adds [watchmy.bike](https://watchmy.bike/), a tool for tracking bikes and components with automatic Strava mileage, maintenance reminders, and public bike profiles. It connects via the Strava API and syncs distance automatically. I'm the developer.

Placed under **Misc. tools** as the closest fit (no maintenance/gear section exists) — happy to move it elsewhere. Followed the existing entry format and alphabetical order within the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)