### PR TITLE
Add trackmy.shoes to Misc. tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,5 @@ A curated list of awesome Strava tools & resources.
 * [StrideStats](https://www.stridestats.com/) - Data about running, set goals, etc.
 * [Summit Bag](https://summitbag.com/) - Automatically identifies your peaks and cols
 * [tapiriik](https://tapiriik.com/) - Sync your fitness data between services
+* [trackmy.shoes](https://trackmy.shoes/) - Track shoe mileage with advanced analytics and health monitoring
 * [watchmy.bike](https://watchmy.bike/) - Track bikes and components with Strava mileage, maintenance reminders, and public bike profiles


### PR DESCRIPTION
Adds [trackmy.shoes](https://trackmy.shoes/) to the **🛠️ Misc. tools** section.

trackmy.shoes lets you track your shoe mileage with advanced analytics and health monitoring. Inserted alphabetically within the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)